### PR TITLE
feat: T11 — AbortSignal propagation + TanStack Query 5 helpers

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@freema/react-admin-api-bundle",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Frontend assets for React Admin API Bundle",
-  "main": "dist/data-provider.js",
-  "types": "dist/data-provider.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
     "src/**/*"
@@ -15,7 +15,8 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "format": "prettier --write src/**/*.ts",
-    "format:check": "prettier --check src/**/*.ts"
+    "format:check": "prettier --check src/**/*.ts",
+    "test": "tsc --noEmit -p tsconfig.test.json && node --test --import tsx 'tests/**/*.test.ts'"
   },
   "keywords": [
     "react-admin",
@@ -39,6 +40,7 @@
     "prettier": "^3.0.0",
     "ra-core": "^5.0.0",
     "react-admin": "^5.0.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.0.0"
   }
 }

--- a/assets/src/abortSignal.ts
+++ b/assets/src/abortSignal.ts
@@ -1,0 +1,62 @@
+/**
+ * Combine 1..N AbortSignals into a single signal that aborts as soon as any input aborts.
+ *
+ * Prefers the native `AbortSignal.any()` (Chrome 116+, FF 124+, Safari 17.4+, Node 20+)
+ * and falls back to a manual implementation in older runtimes.
+ *
+ * `undefined` / `null` entries are ignored so callers can pass optional sources without
+ * pre-filtering.
+ */
+export const combineSignals = (
+    ...signals: ReadonlyArray<AbortSignal | undefined | null>
+): AbortSignal | undefined => {
+    const real = signals.filter((s): s is AbortSignal => Boolean(s));
+    if (real.length === 0) {
+        return undefined;
+    }
+    if (real.length === 1) {
+        return real[0];
+    }
+
+    const nativeAny = (AbortSignal as unknown as { any?: (s: AbortSignal[]) => AbortSignal }).any;
+    if (typeof nativeAny === 'function') {
+        return nativeAny.call(AbortSignal, real);
+    }
+
+    const controller = new AbortController();
+    const abort = (signal: AbortSignal): void => {
+        if (!controller.signal.aborted) {
+            controller.abort((signal as AbortSignal & { reason?: unknown }).reason);
+        }
+    };
+    for (const signal of real) {
+        if (signal.aborted) {
+            abort(signal);
+            break;
+        }
+        signal.addEventListener('abort', () => abort(signal), { once: true });
+    }
+    return controller.signal;
+};
+
+/**
+ * Build a signal that aborts after `ms` milliseconds. Prefers the native
+ * `AbortSignal.timeout()` (Chrome 103+, FF 100+, Safari 16+, Node 17.3+).
+ */
+export const timeoutSignal = (ms: number): AbortSignal => {
+    const nativeTimeout = (AbortSignal as unknown as { timeout?: (ms: number) => AbortSignal })
+        .timeout;
+    if (typeof nativeTimeout === 'function') {
+        return nativeTimeout.call(AbortSignal, ms);
+    }
+
+    const controller = new AbortController();
+    setTimeout(() => {
+        if (!controller.signal.aborted) {
+            controller.abort(
+                Object.assign(new Error(`Request timed out after ${ms}ms`), { name: 'TimeoutError' }),
+            );
+        }
+    }, ms);
+    return controller.signal;
+};

--- a/assets/src/customDataProvider.ts
+++ b/assets/src/customDataProvider.ts
@@ -1,16 +1,51 @@
 import type { DataProvider } from 'react-admin';
 import { fetchUtils } from 'ra-core';
+import { combineSignals, timeoutSignal } from './abortSignal';
+import type { ReactAdminApiOptions } from './types';
+
+type FetchOptions = RequestInit & { signal?: AbortSignal };
 
 /**
- * Custom data provider for React Admin API Bundle
- * This is the default provider that matches the bundle's API format
+ * Custom data provider for React Admin API Bundle.
+ *
+ * Supports:
+ * - AbortSignal propagation from react-admin / TanStack Query 5 (request cancellation).
+ * - Optional per-request timeout (`opts.timeoutMs`).
+ * - Caller-supplied default fetch options (`opts.fetchOptions`), e.g. `{ credentials: 'include' }`.
  */
-export const customDataProvider = (apiUrl: string): DataProvider => {
-    const httpClient = (url: string, options: any = {}) => {
-        if (!options.headers) {
-            options.headers = new Headers({ Accept: 'application/json' });
+export const customDataProvider = (
+    apiUrl: string,
+    opts: ReactAdminApiOptions = {},
+): DataProvider => {
+    const { timeoutMs, fetchOptions } = opts;
+
+    const buildSignal = (incoming?: AbortSignal): AbortSignal | undefined => {
+        const signals: Array<AbortSignal | undefined> = [];
+        if (fetchOptions && 'signal' in fetchOptions) {
+            const optsSignal = (fetchOptions as RequestInit).signal;
+            if (optsSignal) {
+                signals.push(optsSignal);
+            }
         }
-        return fetchUtils.fetchJson(url, options);
+        if (incoming) {
+            signals.push(incoming);
+        }
+        if (typeof timeoutMs === 'number' && timeoutMs > 0) {
+            signals.push(timeoutSignal(timeoutMs));
+        }
+        return combineSignals(...signals);
+    };
+
+    const httpClient = (url: string, options: FetchOptions = {}) => {
+        const merged: FetchOptions = { ...(fetchOptions as RequestInit | undefined), ...options };
+        if (!merged.headers) {
+            merged.headers = new Headers({ Accept: 'application/json' });
+        }
+        const signal = buildSignal(options.signal);
+        if (signal) {
+            merged.signal = signal;
+        }
+        return fetchUtils.fetchJson(url, merged);
     };
 
     return {
@@ -25,7 +60,7 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
                 filter: JSON.stringify(params.filter || {}),
             };
             const url = `${apiUrl}/${resource}?${fetchUtils.queryParameters(query)}`;
-            const { json, headers } = await httpClient(url);
+            const { json, headers } = await httpClient(url, { signal: params.signal });
             return {
                 data: json.data,
                 total: parseInt(headers.get('x-content-range') || json.total || '0', 10),
@@ -33,7 +68,9 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
         },
 
         getOne: async (resource, params) => {
-            const { json } = await httpClient(`${apiUrl}/${resource}/${params.id}`);
+            const { json } = await httpClient(`${apiUrl}/${resource}/${params.id}`, {
+                signal: params.signal,
+            });
             return { data: json };
         },
 
@@ -42,7 +79,7 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
                 filter: JSON.stringify({ id: params.ids }),
             };
             const url = `${apiUrl}/${resource}?${fetchUtils.queryParameters(query)}`;
-            const { json } = await httpClient(url);
+            const { json } = await httpClient(url, { signal: params.signal });
             return { data: json.data };
         },
 
@@ -60,7 +97,7 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
                 }),
             };
             const url = `${apiUrl}/${resource}?${fetchUtils.queryParameters(query)}`;
-            const { json, headers } = await httpClient(url);
+            const { json, headers } = await httpClient(url, { signal: params.signal });
             return {
                 data: json.data,
                 total: parseInt(headers.get('x-content-range') || json.total || '0', 10),
@@ -71,6 +108,7 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
             const { json } = await httpClient(`${apiUrl}/${resource}/${params.id}`, {
                 method: 'PUT',
                 body: JSON.stringify(params.data),
+                signal: params.signal,
             });
             return { data: json };
         },
@@ -81,8 +119,9 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
                     httpClient(`${apiUrl}/${resource}/${id}`, {
                         method: 'PUT',
                         body: JSON.stringify(params.data),
-                    })
-                )
+                        signal: params.signal,
+                    }),
+                ),
             );
             return { data: responses.map(({ json }) => json.id) };
         },
@@ -91,6 +130,7 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
             const { json } = await httpClient(`${apiUrl}/${resource}`, {
                 method: 'POST',
                 body: JSON.stringify(params.data),
+                signal: params.signal,
             });
             return { data: { ...params.data, id: json.id } as any };
         },
@@ -98,6 +138,7 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
         delete: async (resource, params) => {
             const { json } = await httpClient(`${apiUrl}/${resource}/${params.id}`, {
                 method: 'DELETE',
+                signal: params.signal,
             });
             return { data: json };
         },
@@ -106,6 +147,7 @@ export const customDataProvider = (apiUrl: string): DataProvider => {
             const { json } = await httpClient(`${apiUrl}/${resource}`, {
                 method: 'DELETE',
                 body: JSON.stringify({ filter: { id: params.ids } }),
+                signal: params.signal,
             });
             return { data: json };
         },

--- a/assets/src/data-provider.ts
+++ b/assets/src/data-provider.ts
@@ -1,18 +1,27 @@
 import { customDataProvider } from './customDataProvider';
-import type { DataProviderFactory } from './types';
+import type { DataProviderFactory, ReactAdminApiOptions } from './types';
 
 /**
- * Create custom data provider for React Admin API Bundle
+ * Create custom data provider for React Admin API Bundle.
+ *
+ * @example
+ *   const dataProvider = createDataProvider('/api/admin');
+ *
+ * @example With cookie auth + 30s timeout:
+ *   const dataProvider = createDataProvider('/api/admin', {
+ *     timeoutMs: 30_000,
+ *     fetchOptions: { credentials: 'include' },
+ *   });
  */
-export const createDataProvider: DataProviderFactory = (apiUrl: string) => {
-    return customDataProvider(apiUrl);
+export const createDataProvider: DataProviderFactory = (
+    apiUrl: string,
+    opts?: ReactAdminApiOptions,
+) => {
+    return customDataProvider(apiUrl, opts);
 };
 
-// Export individual providers
 export { customDataProvider };
 
-// Export types
-export type { DataProviderFactory };
+export type { DataProviderFactory, ReactAdminApiOptions };
 
-// Default export
 export default createDataProvider;

--- a/assets/src/index.ts
+++ b/assets/src/index.ts
@@ -1,14 +1,19 @@
 /**
- * React Admin API Bundle - Frontend Assets
- * 
- * This package provides data provider for React Admin applications
- * that integrate with the React Admin API Bundle for Symfony.
+ * React Admin API Bundle — Frontend Assets
+ *
+ * This package provides a TypeScript data provider for React Admin applications that
+ * integrate with the Freema\ReactAdminApiBundle Symfony bundle.
  */
 
 export {
     createDataProvider,
     customDataProvider,
 } from './data-provider';
+
+export { combineSignals, timeoutSignal } from './abortSignal';
+
+export { getResourceQueryKeys } from './queryKeys';
+export type { ResourceQueryKeys } from './queryKeys';
 
 export type {
     ReactAdminApiOptions,
@@ -20,5 +25,4 @@ export type {
     DeleteResponse,
 } from './types';
 
-// Default export
 export { default } from './data-provider';

--- a/assets/src/queryKeys.ts
+++ b/assets/src/queryKeys.ts
@@ -1,0 +1,30 @@
+/**
+ * TanStack Query 5 / react-admin 5 query-key helpers.
+ *
+ * These mirror the keys react-admin uses internally so consumers can call
+ * `queryClient.invalidateQueries(getResourceQueryKeys('users').lists)` after a mutation
+ * without guessing the key shape.
+ *
+ * The values are typed `as const` so consumers get exact tuple types in TypeScript.
+ */
+export const getResourceQueryKeys = (resource: string) => ({
+    /** All queries for the resource (lists + detail + custom). */
+    all: [resource] as const,
+    /** Every getList query (any params). */
+    lists: [resource, 'getList'] as const,
+    /** A specific getList query (use the same params you pass to dataProvider.getList). */
+    list: (params: unknown) => [resource, 'getList', params] as const,
+    /** Every getOne query. */
+    details: [resource, 'getOne'] as const,
+    /** A specific getOne query (by id). */
+    detail: (id: string | number) => [resource, 'getOne', { id }] as const,
+    /** Every getMany query. */
+    many: [resource, 'getMany'] as const,
+    /** Every getManyReference query (any target). */
+    manyReferences: [resource, 'getManyReference'] as const,
+    /** A specific getManyReference query by target + id. */
+    manyReference: (target: string, id: string | number) =>
+        [resource, 'getManyReference', { target, id }] as const,
+});
+
+export type ResourceQueryKeys = ReturnType<typeof getResourceQueryKeys>;

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -1,7 +1,21 @@
 import type { DataProvider } from 'react-admin';
 
 export interface ReactAdminApiOptions {
-    apiUrl: string;
+    /**
+     * Per-request timeout in milliseconds. If a request exceeds this duration the underlying
+     * fetch is aborted (combined with any AbortSignal supplied by react-admin / TanStack Query).
+     *
+     * Default: undefined (no timeout — rely on the caller's own AbortSignal).
+     */
+    timeoutMs?: number;
+
+    /**
+     * Additional fetch options merged into every request (e.g. `{ credentials: 'include' }`).
+     *
+     * Note: `signal`, `method`, `body`, and `headers` are managed by the data provider itself
+     * and will override anything supplied here.
+     */
+    fetchOptions?: Omit<RequestInit, 'signal' | 'method' | 'body' | 'headers'>;
 }
 
 export interface ListResponse<T = any> {
@@ -25,4 +39,4 @@ export interface DeleteResponse<T = any> {
     data: T;
 }
 
-export type DataProviderFactory = (apiUrl: string) => DataProvider;
+export type DataProviderFactory = (apiUrl: string, opts?: ReactAdminApiOptions) => DataProvider;

--- a/assets/tests/abortSignal.test.ts
+++ b/assets/tests/abortSignal.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { combineSignals, timeoutSignal } from '../src/abortSignal';
+
+test('combineSignals returns undefined when no signals are provided', () => {
+    assert.equal(combineSignals(), undefined);
+    assert.equal(combineSignals(undefined, null), undefined);
+});
+
+test('combineSignals returns the single signal verbatim', () => {
+    const ctrl = new AbortController();
+    assert.equal(combineSignals(ctrl.signal), ctrl.signal);
+});
+
+test('combineSignals aborts when any input signal aborts', () => {
+    const a = new AbortController();
+    const b = new AbortController();
+    const combined = combineSignals(a.signal, b.signal);
+    assert.ok(combined);
+    assert.equal(combined!.aborted, false);
+
+    b.abort('reason-b');
+    assert.equal(combined!.aborted, true);
+});
+
+test('combineSignals is already aborted when an input was aborted up-front', () => {
+    const a = new AbortController();
+    a.abort('pre-aborted');
+    const b = new AbortController();
+    const combined = combineSignals(a.signal, b.signal);
+    assert.ok(combined);
+    assert.equal(combined!.aborted, true);
+});
+
+test('timeoutSignal aborts after the configured delay', async () => {
+    const signal = timeoutSignal(20);
+    assert.equal(signal.aborted, false);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(signal.aborted, true);
+});

--- a/assets/tests/customDataProvider.test.ts
+++ b/assets/tests/customDataProvider.test.ts
@@ -1,0 +1,100 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { customDataProvider } from '../src/customDataProvider';
+
+interface CapturedCall {
+    url: string;
+    init: RequestInit;
+}
+
+const makeFetchStub = (
+    response: { status?: number; body?: unknown; headers?: Record<string, string> } = {},
+) => {
+    const calls: CapturedCall[] = [];
+    const stub = (url: string, init: RequestInit = {}) => {
+        calls.push({ url, init });
+        if (init.signal?.aborted) {
+            return Promise.reject(
+                Object.assign(new Error('Aborted'), { name: 'AbortError' }),
+            );
+        }
+        return new Promise((resolve, reject) => {
+            const headers = new Headers(response.headers ?? {});
+            const body = JSON.stringify(response.body ?? { data: [], total: 0 });
+            const onAbort = (): void => {
+                reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }));
+            };
+            init.signal?.addEventListener('abort', onAbort, { once: true });
+            setTimeout(() => {
+                init.signal?.removeEventListener('abort', onAbort);
+                resolve({
+                    status: response.status ?? 200,
+                    statusText: 'OK',
+                    headers,
+                    ok: true,
+                    text: () => Promise.resolve(body),
+                });
+            }, 10);
+        }) as unknown as Promise<Response>;
+    };
+    return { stub, calls };
+};
+
+test('getList forwards the AbortSignal supplied by react-admin to fetch', async () => {
+    const original = globalThis.fetch;
+    const { stub, calls } = makeFetchStub({ body: { data: [], total: 0 } });
+    globalThis.fetch = stub as unknown as typeof fetch;
+    try {
+        const provider = customDataProvider('/api');
+        const controller = new AbortController();
+        const promise = provider.getList('users', {
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: {},
+            signal: controller.signal,
+        } as any);
+        controller.abort();
+        await assert.rejects(promise, (err: { name?: string }) => err.name === 'AbortError');
+        assert.ok(calls.length === 1, 'fetch was called once');
+        assert.ok(calls[0].init.signal, 'a signal was forwarded');
+    } finally {
+        globalThis.fetch = original;
+    }
+});
+
+test('timeoutMs aborts the request when no response arrives in time', async () => {
+    const original = globalThis.fetch;
+    const slow = (url: string, init: RequestInit = {}) =>
+        new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => {
+                reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }));
+            }, { once: true });
+        }) as unknown as Promise<Response>;
+    globalThis.fetch = slow as unknown as typeof fetch;
+    try {
+        const provider = customDataProvider('/api', { timeoutMs: 25 });
+        const start = Date.now();
+        await assert.rejects(
+            provider.getOne('users', { id: 1 } as any),
+            (err: { name?: string }) => err.name === 'AbortError' || err.name === 'TimeoutError',
+        );
+        assert.ok(Date.now() - start < 500, 'aborted well within 500ms');
+    } finally {
+        globalThis.fetch = original;
+    }
+});
+
+test('fetchOptions defaults (e.g. credentials) are merged into every request', async () => {
+    const original = globalThis.fetch;
+    const { stub, calls } = makeFetchStub({ body: { id: 1 } });
+    globalThis.fetch = stub as unknown as typeof fetch;
+    try {
+        const provider = customDataProvider('/api', {
+            fetchOptions: { credentials: 'include' },
+        });
+        await provider.getOne('users', { id: 1 } as any);
+        assert.equal(calls[0].init.credentials, 'include');
+    } finally {
+        globalThis.fetch = original;
+    }
+});

--- a/assets/tests/queryKeys.test.ts
+++ b/assets/tests/queryKeys.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { getResourceQueryKeys } from '../src/queryKeys';
+
+test('getResourceQueryKeys produces the expected hierarchy', () => {
+    const keys = getResourceQueryKeys('users');
+    assert.deepEqual(keys.all, ['users']);
+    assert.deepEqual(keys.lists, ['users', 'getList']);
+    assert.deepEqual(keys.list({ filter: { active: true } }), [
+        'users',
+        'getList',
+        { filter: { active: true } },
+    ]);
+    assert.deepEqual(keys.details, ['users', 'getOne']);
+    assert.deepEqual(keys.detail(42), ['users', 'getOne', { id: 42 }]);
+    assert.deepEqual(keys.detail('abc'), ['users', 'getOne', { id: 'abc' }]);
+    assert.deepEqual(keys.many, ['users', 'getMany']);
+    assert.deepEqual(keys.manyReferences, ['users', 'getManyReference']);
+    assert.deepEqual(keys.manyReference('postId', 7), [
+        'users',
+        'getManyReference',
+        { target: 'postId', id: 7 },
+    ]);
+});
+
+test('getResourceQueryKeys keys for different resources do not collide', () => {
+    const users = getResourceQueryKeys('users');
+    const posts = getResourceQueryKeys('posts');
+    assert.notDeepEqual(users.lists, posts.lists);
+    assert.notDeepEqual(users.detail(1), posts.detail(1));
+});

--- a/assets/tsconfig.test.json
+++ b/assets/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "."
+    },
+    "include": ["src/**/*", "tests/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/doc/cancellation.md
+++ b/doc/cancellation.md
@@ -1,0 +1,85 @@
+# Request cancellation, timeouts and TanStack Query keys
+
+`@freema/react-admin-api-bundle` 1.1+ propagates **`AbortSignal`** through every data-provider method and ships first-class TanStack Query key helpers.
+
+## Why it matters
+
+React-admin 5 builds on **TanStack Query 5**, which gives every `queryFn` an `AbortSignal` that fires when the React tree unmounts the consumer, when navigation supersedes the current screen, or when the user types in a search box that supersedes an older list query. Without forwarding that signal into `fetch`, stale requests continue to run after the user already moved on. With React 19 concurrent rendering + Suspense the cost is amplified — a single user gesture can trigger several speculative renders, each one issuing a request the next render would otherwise discard.
+
+## Forwarding the react-admin signal
+
+The bundled data provider does the wiring for you — every CRUD method (`getList`, `getOne`, `getMany`, `getManyReference`, `create`, `update`, `updateMany`, `delete`, `deleteMany`) passes `params.signal` into `fetch` after combining it with any default signal you supplied on construction.
+
+```ts
+import { createDataProvider } from '@freema/react-admin-api-bundle';
+
+const dataProvider = createDataProvider('/api/admin');
+// react-admin will pass its own AbortSignal in params.signal; nothing else to do.
+```
+
+## Adding a per-request timeout
+
+```ts
+const dataProvider = createDataProvider('/api/admin', {
+    timeoutMs: 30_000,
+});
+```
+
+When the configured timeout elapses without a response the request is aborted with an `AbortError` / `TimeoutError`. The timeout is composed *together* with the react-admin signal — whichever fires first wins.
+
+## Adding default fetch options (cookies, headers, ...)
+
+```ts
+const dataProvider = createDataProvider('/api/admin', {
+    fetchOptions: { credentials: 'include' },
+});
+```
+
+`signal`, `method`, `body` and `headers` set by the provider always override `fetchOptions` (the type system enforces this).
+
+## Cancelling queries manually
+
+Use `getResourceQueryKeys()` to obtain stable TanStack Query key tuples that mirror what react-admin uses internally:
+
+```ts
+import { useQueryClient } from '@tanstack/react-query';
+import { getResourceQueryKeys } from '@freema/react-admin-api-bundle';
+
+const usersKeys = getResourceQueryKeys('users');
+
+// Cancel every in-flight list query for `users` (e.g. when leaving the screen).
+queryClient.cancelQueries({ queryKey: usersKeys.lists });
+
+// Invalidate one specific row after a mutation.
+queryClient.invalidateQueries({ queryKey: usersKeys.detail(42) });
+
+// Invalidate every query under the resource (rarely needed).
+queryClient.invalidateQueries({ queryKey: usersKeys.all });
+```
+
+The available keys are:
+
+| Helper | Tuple |
+|---|---|
+| `keys.all` | `['<resource>']` |
+| `keys.lists` | `['<resource>', 'getList']` |
+| `keys.list(params)` | `['<resource>', 'getList', params]` |
+| `keys.details` | `['<resource>', 'getOne']` |
+| `keys.detail(id)` | `['<resource>', 'getOne', { id }]` |
+| `keys.many` | `['<resource>', 'getMany']` |
+| `keys.manyReferences` | `['<resource>', 'getManyReference']` |
+| `keys.manyReference(target, id)` | `['<resource>', 'getManyReference', { target, id }]` |
+
+## Combining signals yourself
+
+If you need to compose signals outside of the data provider (e.g. inside a custom React hook), use the same helper the provider uses:
+
+```ts
+import { combineSignals, timeoutSignal } from '@freema/react-admin-api-bundle';
+
+const userSignal = controller.signal;
+const combined = combineSignals(userSignal, timeoutSignal(5_000));
+await fetch(url, { signal: combined });
+```
+
+Both helpers prefer the native `AbortSignal.any()` / `AbortSignal.timeout()` when available and fall back to a hand-rolled implementation in older runtimes.


### PR DESCRIPTION
## Summary

Adds **`AbortSignal` propagation** + **TanStack Query 5 key helpers** + **per-request timeout** + **default fetchOptions** to the bundle's TypeScript data provider. Fully backward compatible (the new constructor argument is optional).

## Motivation

React-admin 5 builds on TanStack Query 5, which passes an `AbortSignal` into every `queryFn` so that requests can be cancelled when the consumer unmounts, when navigation supersedes the current screen, or when a stale list query is replaced by a new one. The current data provider drops `params.signal` on the floor, which:

- leaks bandwidth (stale requests keep running)
- breaks RA's own race-condition prevention (newer responses can be overtaken by older slow ones)
- gets worse under React 19 concurrent rendering + Suspense, where the same render path can issue several speculative requests

Additionally consumers manipulating the query cache by hand had to hard-code RA's internal query-key shape — error prone, brittle across RA upgrades.

## What's in

- `customDataProvider` forwards `params.signal` from every CRUD method (`getList`, `getOne`, `getMany`, `getManyReference`, `create`, `update`, `updateMany`, `delete`, `deleteMany`) into `fetch`.
- `createDataProvider(apiUrl, opts?)` now takes an optional `opts`:
  - `timeoutMs?: number` -- installs `AbortSignal.timeout(...)` combined with the caller's signal.
  - `fetchOptions?: Omit<RequestInit, 'signal' | 'method' | 'body' | 'headers'>` -- merged into every request (e.g. `{ credentials: 'include' }`).
- New helpers:
  - `combineSignals(...signals)` -- prefers `AbortSignal.any()`, falls back to a manual implementation.
  - `timeoutSignal(ms)` -- prefers `AbortSignal.timeout()`, falls back to a setTimeout-based abort.
  - `getResourceQueryKeys(resource)` -- returns the tuple shape RA itself uses for TanStack Query keys, so callers can `queryClient.invalidateQueries({ queryKey: keys.detail(id) })` without guessing.
- All helpers re-exported from `index.ts` (and the default export remains `data-provider.ts` for backward compatibility).
- Tests under `assets/tests/` cover the combiner, the timeout fallback, signal forwarding, default-options merge, and the query-key tuples (`node --test` via `tsx`, no extra framework needed).
- New documentation page `doc/cancellation.md` with usage examples for cancellation, timeouts, fetchOptions, and TanStack Query key helpers.

## Breaking changes

None. `createDataProvider(url)` without options behaves exactly as before. The package main/types entry was repointed from `dist/data-provider.*` to `dist/index.*` so consumers using named imports (`import { getResourceQueryKeys }`) pick up the new exports out of the box; default-import users (`import createDataProvider from '@freema/react-admin-api-bundle'`) keep working because `index.ts` re-exports the same default.

Version bumped 1.0.0 -> **1.1.0** (additive, semver minor).

## Test plan

- [ ] `npm install` resolves `tsx` 4.x.
- [ ] `npm run test` -- runs `tsc --noEmit -p tsconfig.test.json` then `node --test` over `tests/`.
- [ ] `npm run build` -- emits the new `dist/index.{js,d.ts}` alongside the existing files.
- [ ] (Manual) drop the built bundle into a RA 5 app, cancel a slow request via `queryClient.cancelQueries({ queryKey: getResourceQueryKeys('users').lists })`, confirm Network panel shows `(cancelled)`.

## Follow-ups

- T12 -- OpenAPI auto-spec + TS codegen from PHP DTO (separate PR).
- T13 -- JWT cookie authProvider helper + ETag/If-Match + multipart upload (separate PR).
- T14 -- React 19 dev-app upgrade (separate PR).
- T15 -- Advanced filter operators + soft-delete + SSE `useGetLive` (separate PR).
