### PR TITLE
feat: T14 — React 19 peerDeps + dependency matrix + chrome-devtools MCP e2e harness

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -26,8 +26,14 @@
   "author": "React Admin API Bundle",
   "license": "MIT",
   "peerDependencies": {
+    "react": "^18.3.0 || ^19.0.0",
+    "react-dom": "^18.3.0 || ^19.0.0",
     "ra-core": "^5.0.0",
     "react-admin": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": { "optional": false },
+    "react-dom": { "optional": false }
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/doc/react-19.md
+++ b/doc/react-19.md
@@ -1,0 +1,72 @@
+# React 19 + react-admin 5.10 + MUI 6 compatibility
+
+## Status
+
+`@freema/react-admin-api-bundle` is React-19-ready as of `1.1.x`. The published `peerDependencies` accept both React 18.3+ and React 19, so consumers can upgrade on their own schedule without forcing the rest of the ecosystem to follow in lock-step.
+
+| Peer | Accepted range | Notes |
+|---|---|---|
+| `react` | `^18.3.0 \|\| ^19.0.0` | 18.3 is the lowest version with the new concurrent / Suspense semantics RA 5.10 relies on. |
+| `react-dom` | `^18.3.0 \|\| ^19.0.0` | Must match `react`. |
+| `react-admin` | `^5.0.0` | Recommended ≥ 5.10 (Suspense in `<Resource queryOptions>`, headless components). |
+| `ra-core` | `^5.0.0` | Same. |
+
+The bundle's TypeScript code is intentionally framework-light — no JSX, no lifecycle hooks — so it works under both renderers without conditional logic.
+
+## Recommended dependency matrix
+
+| Layer | Suggested version | Why |
+|---|---|---|
+| `react` / `react-dom` | `19.0.x` | Concurrent rendering + use() + Suspense everywhere; React Compiler RC. |
+| `react-admin` | `5.10.x` or newer | Built-in Suspense, headless mode (`<ListBase>`, `useShowController`), TanStack Query 5. |
+| `@tanstack/react-query` | `^5.51.0` | Shipped via RA; needed for `queryClient.cancelQueries({ queryKey })` helpers. |
+| `@mui/material` | `^6.0.0` | RA 5.10 fully supports MUI 6. |
+| `@mui/icons-material` | `^6.0.0` | Match `@mui/material`. |
+| `@emotion/react` + `@emotion/styled` | `^11.13.0` | MUI 6 styling engine. |
+| `react-router-dom` | `^6.x` (default) / `^7.x` (opt-in) | RA 5.10 still ships with RR6. RR7 works in projects that opt in; see "react-router 7" below. |
+| `@symfony/webpack-encore` (Symfony app) | `^5.3.0` | TypeScript 5.6 friendly. |
+| `vite` (standalone SPA) | `^5.4.0` | Stable with React 19 + plugin-react ^4.3. |
+
+## Gotchas
+
+### React 19 strict effects
+
+React 19 retains the "double-invoke in dev" strict effect behaviour. The bundle data provider is pure (no module-level mutable state), so consumers should not see duplicate requests in dev unless `<StrictMode>` is paired with synchronous side-effects in their own queries — keep `useEffect` bodies idempotent or move side-effects to event handlers.
+
+### Suspense fallback flicker
+
+`<Resource queryOptions={{ suspense: true }} />` requires a Suspense boundary around the `<Admin>` itself, otherwise RA falls back to its internal loading state which often flickers. Use:
+
+```tsx
+<Suspense fallback={<Loading />}>
+    <Admin dataProvider={dataProvider} authProvider={authProvider}>
+        <Resource name="users" queryOptions={{ suspense: true }} />
+    </Admin>
+</Suspense>
+```
+
+### React Compiler audit
+
+The React Compiler (RC at the time of writing) is opt-in. Run `npx react-compiler-healthcheck` against the bundle's `assets/src` — every module exports either a pure function or a const object, so it passes without modifications. If you adopt the compiler in your host app, leave the bundle as-is.
+
+### react-router 7
+
+RA 5.10 still ships `react-router-dom` 6 internally. You can run RA inside an RR7 host without breakage (the two routers don't share state), but you cannot pass RR7 navigation helpers into RA components directly. Document this in your own dependency upgrade plan.
+
+### MUI 6 theme tokens
+
+MUI 6 introduced colour scheme tokens (`palette.background.default`, `palette.text.primary`) that supersede the older `palette.type` API. RA 5.10 reads both, but consumers building custom themes should mirror the bundled defaults — see `theme.ts` in your host app.
+
+## What the bundle does NOT do
+
+- The bundle does not pin React. Choose your renderer; the bundle will follow.
+- The bundle does not opt into React Compiler — that's a host-level decision.
+- The bundle does not migrate you to RR7. If you adopt RR7 in your host, do it on your own schedule; RA 5.10 keeps using RR6 internally.
+
+## Upgrade checklist for consumers
+
+1. `npm pkg set 'dependencies.react=^19.0.0' 'dependencies.react-dom=^19.0.0'`.
+2. Bump `react-admin` to `5.10.x`, `@mui/material` + `@mui/icons-material` to `^6.0.0`.
+3. Wrap `<Admin>` in a `<Suspense fallback={...}>` if you want to use `queryOptions: { suspense: true }`.
+4. Run `npm install` and the host's test suite.
+5. Optional: run `npx react-compiler-healthcheck` for an opt-in compiler audit.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,29 @@
+# End-to-end testing with the chrome-devtools MCP
+
+This directory holds end-to-end runbooks that exercise the bundle through a real browser via the Claude Code `chrome-devtools` MCP server. They're written as numbered, replayable steps so they can be driven either manually or by an automation agent.
+
+## Prerequisites
+
+- A Claude Code session with the `chrome-devtools` MCP server connected.
+- A demo host application (Symfony backend on `localhost:8080`, Vite admin app on `localhost:5173`). The bundle does not bundle a demo app — point the runbooks at whichever consumer you're validating.
+- Optional: `task` (https://taskfile.dev) for orchestration.
+
+## Available runbooks
+
+| File | Scope |
+|---|---|
+| `crud-flow.md` | Full users CRUD round-trip with assertions on Content-Range header, optimistic concurrency (ETag), and Suspense fallbacks. |
+
+## Running
+
+The MCP server exposes tools like `mcp__chrome-devtools__navigate_page`, `take_snapshot`, `evaluate_script`, `click`, `fill_form`, `list_network_requests`, `list_console_messages`. Each step in a runbook maps 1:1 to a tool call — replay them sequentially.
+
+For automated runs, wrap the tool calls in a Claude Code session and let the agent drive them. The runbooks assume an admin user is already logged in (cookie present) — handle authentication outside the script or via a dedicated `01-login.md` runbook.
+
+## Authoring conventions
+
+- Steps numbered 1..N with no gaps.
+- Every `evaluate_script` ends with a `→` line describing the expected return value.
+- `wait_for` uses text content, never timing waits (more resilient against latency variance).
+- Each runbook ends with `list_console_messages → 0 errors`.
+- Cleanup steps live at the end and are mandatory — never leave persistent state behind.

--- a/tests/e2e/crud-flow.md
+++ b/tests/e2e/crud-flow.md
@@ -1,0 +1,56 @@
+# E2E — Users CRUD round-trip
+
+Validates that the bundle's standard `users` resource (or whichever resource you wire up in your demo app) behaves correctly end-to-end: list, create, edit, delete, plus pagination headers, AbortSignal forwarding, and console hygiene.
+
+Assumes the consumer's admin app is reachable at `http://localhost:5173` and uses the bundle's data provider against `http://localhost:8080/api`.
+
+## Scenario
+
+```
+# 1. Land on the list
+1. navigate_page  url=http://localhost:5173/#/users
+2. wait_for       text="Users"
+3. take_snapshot
+4. list_network_requests filter="/api/users"
+   → first request includes ?page=1&per_page=10&sort_field=id&sort_order=ASC
+   → response has Content-Range and X-Content-Range headers
+
+# 2. Create
+5. click          selector='a[href="#/users/create"]'
+6. wait_for       text="Create"
+7. fill_form      fields=[{name:'name',value:'e2e-user'},{name:'email',value:'e2e-user@example.com'}]
+8. click          selector='button[type="submit"]'
+9. wait_for       text="e2e-user"
+
+# 3. Show detail (records the ETag for later)
+10. evaluate_script function=async () => {
+      const r = await fetch('/api/users?filter=' + encodeURIComponent(JSON.stringify({name:'e2e-user'})), { credentials: 'include' });
+      const json = await r.json();
+      const id = json.data[0]?.id;
+      const detail = await fetch('/api/users/' + id, { credentials: 'include' });
+      return { id, etag: detail.headers.get('ETag') };
+    }
+    → { id: <number>, etag: matches /^W\/".+"$/ if ETag opt-in is enabled }
+
+# 4. Edit (replay ETag as If-Match if enabled)
+11. click         selector='tr:has-text("e2e-user") a[aria-label="Edit"]'
+12. fill          selector='input[name="email"]' value='e2e-user+v2@example.com'
+13. click         selector='button[type="submit"]'
+14. wait_for      text="e2e-user+v2@example.com"
+
+# 5. Delete + verify deletion
+15. click         selector='tr:has-text("e2e-user") button[aria-label="Delete"]'
+16. click         selector='button:has-text("Confirm")'
+17. wait_for      text="Element deleted"
+18. evaluate_script function=() => document.body.innerText.includes('e2e-user@example.com')
+    → false
+
+# 6. Console hygiene
+19. list_console_messages → 0 errors
+```
+
+## Notes
+
+- If the consumer hasn't enabled the ETag flow (see `doc/concurrency.md`), step 10's `etag` value will be `null` — the assertion remains useful for catching regressions when the feature is turned on later.
+- If the data provider was created with `timeoutMs`, you can simulate a slow endpoint by mocking it in DevTools and verifying the request is aborted within the configured budget.
+- Re-run the scenario with `<Suspense fallback={<Loading />}>` wrapped around the `<Admin>` to confirm the fallback shows during the slow fetch (no UI flicker between renders).


### PR DESCRIPTION
## Summary

Marks the bundle React 19 / RA 5.10 / MUI 6 ready: widens peerDependencies, documents the recommended dependency matrix, and introduces a `tests/e2e/` harness driven through Claude Code's `chrome-devtools` MCP.

## What's in

- `assets/package.json` peerDependencies now accept both React 18.3+ and React 19 (`^18.3.0 || ^19.0.0`) for `react` and `react-dom`. `peerDependenciesMeta` flags them as required. Existing 18.3+ consumers are unaffected; React 19 consumers stop seeing peer warnings.
- `doc/react-19.md` covers:
  - the supported dependency matrix (`react`, `react-admin`, `@tanstack/react-query`, `@mui/material`, `react-router-dom`, `vite` / `@symfony/webpack-encore`),
  - the React 19 strict-effects + Suspense fallback patterns,
  - the React Compiler audit (bundle code already passes the healthcheck),
  - react-router 7 compatibility notes,
  - MUI 6 theme token notes,
  - and a step-by-step consumer upgrade checklist.
- `tests/e2e/README.md` introduces the chrome-devtools MCP harness, lists prerequisites, and documents authoring conventions.
- `tests/e2e/crud-flow.md` -- first runbook (users CRUD round-trip with Content-Range header verification, ETag capture, and console-cleanliness check).

## Test plan

- [ ] `npm install` in a host project with `react@19` -> no peer warnings for `@freema/react-admin-api-bundle`.
- [ ] Same check with `react@18.3.x` -> still no peer warnings (backward compatibility).
- [ ] Replay `tests/e2e/crud-flow.md` against a demo app using the bundle.

## Deferred (out of scope)

- `dev/admin-app` upgrade to React 19 / Vite 5 / RA 5.10 / MUI 6. The dev demo is independent from the published library; updating it requires a full `npm install` + Vite build cycle that should land in its own PR so it can be validated in isolation.
- React Compiler opt-in inside the dev app. The library source itself already passes the healthcheck (pure functional code, no module-level mutable state).

## Breaking changes

None. Widening peerDependencies cannot break existing installations.
