### PR TITLE
feat: T15 — Filter operator parser + soft-delete trait + SSE subscribeResource helper

### DIFF
--- a/assets/src/realtime/subscribeResource.ts
+++ b/assets/src/realtime/subscribeResource.ts
@@ -1,0 +1,61 @@
+/**
+ * Minimal Server-Sent Events helper for streaming resource events from the bundle's
+ * future `/api/_stream/{resource}` endpoint (or any compatible Mercure topic).
+ *
+ * Each parsed event is delivered to the callback as `{ type, payload }`; the caller
+ * is responsible for invoking `queryClient.invalidateQueries(...)` etc.
+ *
+ * Returns an `unsubscribe` function that closes the underlying EventSource.
+ */
+export interface ResourceEvent {
+    type: 'created' | 'updated' | 'deleted' | 'ping' | string;
+    payload?: unknown;
+    id?: string | number;
+}
+
+export interface SubscribeOptions {
+    /** Override the EventSource URL. Default: `${apiUrl}/_stream/${resource}`. */
+    url?: string;
+    /**
+     * Pass-through to `new EventSource(url, { withCredentials })`. Defaults to true
+     * so the existing session cookie is sent along.
+     */
+    withCredentials?: boolean;
+    /** Callback invoked on connection errors (network drop, server down, etc.). */
+    onError?: (err: Event) => void;
+    /**
+     * Optional EventSource constructor override -- useful for tests or when running
+     * inside a worker that needs the `eventsource` npm polyfill.
+     */
+    eventSourceImpl?: typeof EventSource;
+}
+
+export const subscribeResource = (
+    apiUrl: string,
+    resource: string,
+    onEvent: (event: ResourceEvent) => void,
+    opts: SubscribeOptions = {},
+): (() => void) => {
+    const url = opts.url ?? `${apiUrl.replace(/\/$/, '')}/_stream/${resource}`;
+    const Impl = opts.eventSourceImpl ?? (typeof EventSource !== 'undefined' ? EventSource : undefined);
+    if (!Impl) {
+        throw new Error('subscribeResource: no global EventSource available -- supply opts.eventSourceImpl');
+    }
+    const source = new Impl(url, { withCredentials: opts.withCredentials ?? true });
+
+    source.onmessage = (msg: MessageEvent): void => {
+        try {
+            const data = JSON.parse((msg.data ?? '').toString());
+            onEvent(data as ResourceEvent);
+        } catch {
+            // Some servers emit ping comments / non-JSON heartbeats; ignore.
+        }
+    };
+    if (opts.onError) {
+        source.onerror = opts.onError;
+    }
+
+    return () => {
+        source.close();
+    };
+};

--- a/assets/tests/subscribeResource.test.ts
+++ b/assets/tests/subscribeResource.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { subscribeResource, type ResourceEvent } from '../src/realtime/subscribeResource';
+
+class FakeEventSource {
+    public readonly url: string;
+    public readonly init: { withCredentials?: boolean };
+    public onmessage: ((event: { data: string }) => void) | null = null;
+    public onerror: ((event: Event) => void) | null = null;
+    public closed = false;
+
+    constructor(url: string, init: { withCredentials?: boolean } = {}) {
+        this.url = url;
+        this.init = init;
+    }
+
+    close(): void {
+        this.closed = true;
+    }
+}
+
+const factory = (): {
+    Impl: typeof EventSource;
+    instances: FakeEventSource[];
+} => {
+    const instances: FakeEventSource[] = [];
+    const Impl = function (url: string, init: { withCredentials?: boolean } = {}) {
+        const es = new FakeEventSource(url, init);
+        instances.push(es);
+        return es;
+    } as unknown as typeof EventSource;
+    return { Impl, instances };
+};
+
+test('subscribeResource builds the default URL and opens a credentialed stream', () => {
+    const { Impl, instances } = factory();
+    const unsubscribe = subscribeResource('https://api.example.com', 'users', () => {}, {
+        eventSourceImpl: Impl,
+    });
+    assert.equal(instances.length, 1);
+    assert.equal(instances[0].url, 'https://api.example.com/_stream/users');
+    assert.equal(instances[0].init.withCredentials, true);
+    unsubscribe();
+    assert.equal(instances[0].closed, true);
+});
+
+test('subscribeResource respects an explicit URL override', () => {
+    const { Impl, instances } = factory();
+    subscribeResource('ignored', 'users', () => {}, {
+        eventSourceImpl: Impl,
+        url: 'https://hub.example.com/topic/users',
+    });
+    assert.equal(instances[0].url, 'https://hub.example.com/topic/users');
+});
+
+test('subscribeResource parses JSON messages and forwards them to the callback', () => {
+    const { Impl, instances } = factory();
+    const received: ResourceEvent[] = [];
+    subscribeResource('https://api.example.com', 'users', (e) => received.push(e), {
+        eventSourceImpl: Impl,
+    });
+    instances[0].onmessage?.({ data: JSON.stringify({ type: 'created', id: 1 }) });
+    instances[0].onmessage?.({ data: JSON.stringify({ type: 'updated', id: 1, payload: { name: 'x' } }) });
+    instances[0].onmessage?.({ data: 'this is a heartbeat comment, not JSON' });
+    assert.equal(received.length, 2);
+    assert.equal(received[0].type, 'created');
+    assert.equal(received[1].payload && (received[1].payload as { name: string }).name, 'x');
+});

--- a/doc/filter-operators.md
+++ b/doc/filter-operators.md
@@ -1,0 +1,107 @@
+# Filter operators
+
+The bundle ships `Freema\ReactAdminApiBundle\Request\FilterOperatorParser`, a tiny helper that interprets react-admin filter keys with operator suffixes (`createdAt_gte`, `email_contains`, `id_in`, …) and returns a `(field, operator)` tuple your `ListTrait` consumer can switch over.
+
+## Why a parser instead of a magic in-built filter
+
+We deliberately kept the operator translation **opt-in**:
+- bundle consumers usually want a whitelist of filterable fields (security: no `password_eq` etc.),
+- the QueryBuilder dialect varies across repositories (joins, aliases, custom filter callbacks),
+- Doctrine query parameter binding has subtle quirks (`IN (:p)` needs an array, `BETWEEN` needs two params, …) that we don't want to monkey-patch into the trait globally.
+
+So the bundle exposes the parser as a service and gives you a recipe for plugging it into your own list method.
+
+## Supported suffixes
+
+| Suffix | Operator key | Typical SQL fragment |
+|---|---|---|
+| `_gt` | `gt` | `field > :p` |
+| `_gte` | `gte` | `field >= :p` |
+| `_lt` | `lt` | `field < :p` |
+| `_lte` | `lte` | `field <= :p` |
+| `_neq` | `neq` | `field != :p` |
+| `_in` | `in` | `field IN (:p)` |
+| `_nin` | `nin` | `field NOT IN (:p)` |
+| `_between` | `between` | `field BETWEEN :pa AND :pb` |
+| `_isNull` | `isNull` | `field IS NULL` |
+| `_isNotNull` | `isNotNull` | `field IS NOT NULL` |
+| `_contains` | `contains` | `field LIKE '%value%'` |
+| `_startsWith` | `startsWith` | `field LIKE 'value%'` |
+| `_endsWith` | `endsWith` | `field LIKE '%value'` |
+| _(none)_ | `eq` | `field = :p` |
+
+The parser scans suffixes longest-first so `createdAt_gte` is never accidentally matched as `_gt`, and `deletedAt_isNotNull` is never matched as `_isNull`.
+
+## Recipe: integrate with your repository
+
+```php
+final class UserRepository extends ServiceEntityRepository implements DataRepositoryListInterface
+{
+    use ListTrait;
+
+    public function __construct(
+        ManagerRegistry $registry,
+        private readonly FilterOperatorParser $operatorParser,
+    ) {
+        parent::__construct($registry, User::class);
+    }
+
+    public function getFullSearchFields(): array { return ['name', 'email']; }
+
+    /** Whitelist of fields filter operators may target. */
+    private const FILTERABLE = ['createdAt', 'email', 'role', 'id', 'age'];
+
+    protected function applyFilters(QueryBuilder $qb, ListDataRequest $req): void
+    {
+        parent::applyFilters($qb, $req);   // keep bundle defaults (q, IN by id, etc.)
+
+        foreach ($req->getFilterValues() as $key => $value) {
+            [$field, $op] = $this->operatorParser->parse($key);
+            if (!in_array($field, self::FILTERABLE, true)) {
+                continue;  // ignore unsupported targets
+            }
+            match ($op) {
+                'gt'         => $qb->andWhere("e.$field > :p_$key")->setParameter("p_$key", $value),
+                'gte'        => $qb->andWhere("e.$field >= :p_$key")->setParameter("p_$key", $value),
+                'lt'         => $qb->andWhere("e.$field < :p_$key")->setParameter("p_$key", $value),
+                'lte'        => $qb->andWhere("e.$field <= :p_$key")->setParameter("p_$key", $value),
+                'neq'        => $qb->andWhere("e.$field != :p_$key")->setParameter("p_$key", $value),
+                'in'         => $qb->andWhere("e.$field IN (:p_$key)")->setParameter("p_$key", (array) $value),
+                'nin'        => $qb->andWhere("e.$field NOT IN (:p_$key)")->setParameter("p_$key", (array) $value),
+                'between'    => $qb
+                    ->andWhere("e.$field BETWEEN :p_{$key}_a AND :p_{$key}_b")
+                    ->setParameter("p_{$key}_a", $value[0])
+                    ->setParameter("p_{$key}_b", $value[1]),
+                'isNull'     => $qb->andWhere("e.$field IS NULL"),
+                'isNotNull'  => $qb->andWhere("e.$field IS NOT NULL"),
+                'contains'   => $qb->andWhere("e.$field LIKE :p_$key")->setParameter("p_$key", '%'.$value.'%'),
+                'startsWith' => $qb->andWhere("e.$field LIKE :p_$key")->setParameter("p_$key", $value.'%'),
+                'endsWith'   => $qb->andWhere("e.$field LIKE :p_$key")->setParameter("p_$key", '%'.$value),
+                default      => $qb->andWhere("e.$field = :p_$key")->setParameter("p_$key", $value),
+            };
+        }
+    }
+}
+```
+
+## Frontend usage
+
+react-admin's `<DateInput source="createdAt_gte" />`, `<NumberInput source="age_between" />` and friends emit the filter keys exactly as the parser expects. No extra glue required.
+
+```tsx
+<List filters={[
+    <DateInput source="createdAt_gte" label="Created from" alwaysOn />,
+    <NumberInput source="age_between" label="Age range" />,
+    <SelectInput source="role_in" choices={ROLES} />,
+]}>
+    <Datagrid>{/* … */}</Datagrid>
+</List>
+```
+
+Numeric `_between` expects an array (`[18, 65]`), so wrap the inputs accordingly (RA's `<NumberInput multiple>` or a custom component).
+
+## Security notes
+
+- **Always** maintain a whitelist of filterable fields. The parser will gladly extract `password_eq` from a query string -- it's the repository's job to ignore it.
+- For `IN` / `NIN`, cast incoming values to arrays before binding.
+- For text operators, do not splice `%` into raw SQL -- always go through parameter binding.

--- a/doc/realtime-sse.md
+++ b/doc/realtime-sse.md
@@ -1,0 +1,104 @@
+# Real-time updates with Server-Sent Events
+
+`@freema/react-admin-api-bundle` ships `subscribeResource(apiUrl, resource, onEvent, opts?)` -- a thin EventSource wrapper that pairs with any SSE source emitting JSON-encoded resource events. The backend side is intentionally pluggable so consumers can choose between a hand-rolled `StreamedResponse`, Symfony Mercure, or a managed CDN like Pusher.
+
+## Event format
+
+The helper parses each `data:` line as JSON and forwards `{ type, payload?, id? }` to the callback:
+
+```ts
+import { subscribeResource } from '@freema/react-admin-api-bundle';
+import { useQueryClient } from '@tanstack/react-query';
+import { getResourceQueryKeys } from '@freema/react-admin-api-bundle';
+
+const NotificationLive = () => {
+    const qc = useQueryClient();
+    useEffect(() => subscribeResource('/api', 'notifications', (event) => {
+        const keys = getResourceQueryKeys('notifications');
+        if (event.type === 'deleted' && event.id) {
+            qc.removeQueries({ queryKey: keys.detail(event.id) });
+        }
+        qc.invalidateQueries({ queryKey: keys.lists });
+    }), [qc]);
+    return null;
+};
+```
+
+Anything that doesn't parse as JSON (heartbeat comments, ping lines emitted by upstream proxies) is silently ignored.
+
+## Options
+
+| Option | Default | Notes |
+|---|---|---|
+| `url` | `${apiUrl}/_stream/${resource}` | Override for Mercure topic URIs (`https://hub/.well-known/mercure?topic=/notifications`). |
+| `withCredentials` | `true` | Forwards the session cookie. Required if the SSE endpoint is auth-gated. |
+| `onError` | `undefined` | Hook for reconnect telemetry or user-visible toast. |
+| `eventSourceImpl` | global `EventSource` | Inject for tests or to use the `eventsource` npm polyfill from a worker. |
+
+The helper returns an unsubscribe function -- call it in your effect's cleanup to close the stream.
+
+## Backend options
+
+The bundle does not ship a pre-baked `/api/_stream/{resource}` controller -- transport choice is project-specific. Three common patterns:
+
+### 1. Symfony Mercure (recommended for production)
+
+```yaml
+# config/packages/mercure.yaml
+mercure:
+    hubs:
+        default:
+            url: 'https://mercure.internal/.well-known/mercure'
+            jwt: { secret: '%env(MERCURE_JWT_SECRET)%' }
+```
+
+Publish from your bundle event listener (`react_admin_api.entity_created` / `_updated` / `_deleted`):
+
+```php
+$this->hub->publish(new Update('/notifications', json_encode([
+    'type' => 'created',
+    'id'   => $entity->getId(),
+])));
+```
+
+Then point the frontend at the Mercure topic:
+
+```ts
+subscribeResource('/api', 'notifications', cb, {
+    url: 'https://mercure.internal/.well-known/mercure?topic=/notifications',
+});
+```
+
+### 2. Symfony `StreamedResponse` (dev / small deployments)
+
+For dev or low-traffic admin apps a polling loop inside `StreamedResponse` is enough:
+
+```php
+#[Route('/api/_stream/{resource}', methods: ['GET'])]
+public function stream(string $resource, EventBuffer $buffer): StreamedResponse
+{
+    return new StreamedResponse(function () use ($resource, $buffer) {
+        while (true) {
+            foreach ($buffer->drain($resource) as $event) {
+                echo "data: " . json_encode($event) . "\n\n";
+            }
+            @ob_flush(); flush();
+            usleep(500_000);
+        }
+    }, headers: [
+        'Content-Type' => 'text/event-stream',
+        'Cache-Control' => 'no-cache, no-transform',
+        'X-Accel-Buffering' => 'no',
+    ]);
+}
+```
+
+`EventBuffer` is your own implementation -- typically a Redis list / pub-sub keyed by resource path. Avoid in-memory buffers in production: the worker recycles will drop events.
+
+### 3. Polling fallback
+
+If no SSE infrastructure is available, react-admin's built-in `useGetLive({ pollInterval: 5000 })` still works against the bundle's plain `GET /api/{resource}/{id}` route -- no extra integration needed.
+
+## Reconnect, retry, backoff
+
+`EventSource` already reconnects automatically with the server-provided `retry:` interval. If you need exponential backoff or auth-token refresh, wrap the helper in your own hook and close + reopen on `onError`.

--- a/doc/soft-delete.md
+++ b/doc/soft-delete.md
@@ -1,0 +1,80 @@
+# Soft delete
+
+The bundle ships `Freema\ReactAdminApiBundle\Interface\SoftDeletableEntityInterface` and `Freema\ReactAdminApiBundle\SoftDeleteTrait` so repositories can convert physical `DELETE` into a `deletedAt` flush without changing the controller path.
+
+## Entity contract
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+use Freema\ReactAdminApiBundle\Interface\SoftDeletableEntityInterface;
+
+#[ORM\Entity(repositoryClass: NotificationRepository::class)]
+class Notification implements SoftDeletableEntityInterface
+{
+    #[ORM\Id, ORM\GeneratedValue, ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $deletedAt = null;
+
+    /* … */
+
+    public function getDeletedAt(): ?\DateTimeImmutable { return $this->deletedAt; }
+    public function setDeletedAt(?\DateTimeImmutable $deletedAt): void { $this->deletedAt = $deletedAt; }
+}
+```
+
+## Repository
+
+Swap `DeleteTrait` for `SoftDeleteTrait`:
+
+```php
+final class NotificationRepository extends ServiceEntityRepository implements
+    DataRepositoryListInterface,
+    DataRepositoryDeleteInterface,
+    DataRepositoryFindInterface
+{
+    use ListTrait;
+    use FindTrait;
+    use SoftDeleteTrait;  // <- delete() now sets deletedAt instead of removing
+
+    public function getFullSearchFields(): array { return ['title']; }
+
+    protected function applyFilters(QueryBuilder $qb, ListDataRequest $req): void
+    {
+        $this->applySoftDeleteScope($qb, 'e', $req->getFilterValues()['include_deleted'] ?? false);
+        parent::applyFilters($qb, $req);
+    }
+}
+```
+
+`applySoftDeleteScope($qb, alias, $includeDeleted)` adds `WHERE alias.deletedAt IS NULL` unless the caller passes `?filter={"include_deleted":1}`. Skip the call entirely if you prefer Doctrine's global filter API.
+
+## Frontend opt-in
+
+The bundle data provider already passes arbitrary filter keys through, so consumers can simply append `include_deleted` to the filter object:
+
+```tsx
+<List filter={{ include_deleted: 1 }} actions={<IncludeDeletedToggle />}>
+    <Datagrid>{/* … */}</Datagrid>
+</List>
+```
+
+## Mixed repositories
+
+If a single repository handles entities of which only some are soft-deletable, `SoftDeleteTrait::delete()` falls back to a physical `remove()` for the non-soft-deletable ones. No second trait or branch needed.
+
+## What about restoring?
+
+Restoration is intentionally not part of the trait -- restoring is a domain decision (some apps want auto-purge after N days, others want admin-only restore). Implement a custom controller / repository method when you need it:
+
+```php
+public function restore(int $id): void
+{
+    $entity = $this->find($id);
+    if ($entity instanceof SoftDeletableEntityInterface) {
+        $entity->setDeletedAt(null);
+        $this->getEntityManager()->flush();
+    }
+}
+```

--- a/src/Interface/SoftDeletableEntityInterface.php
+++ b/src/Interface/SoftDeletableEntityInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Freema\ReactAdminApiBundle\Interface;
+
+/**
+ * Mark an entity as soft-deletable so the bundle can:
+ *   - exclude soft-deleted rows from default list queries,
+ *   - opt-in include them via `?include_deleted=1`,
+ *   - convert DELETE requests into a `setDeletedAt(now())` flush instead of a physical remove.
+ *
+ * Implementations typically pair this with a Doctrine `deleted_at` DATETIME column.
+ */
+interface SoftDeletableEntityInterface extends AdminEntityInterface
+{
+    public function getDeletedAt(): ?\DateTimeImmutable;
+
+    public function setDeletedAt(?\DateTimeImmutable $deletedAt): void;
+}

--- a/src/Request/FilterOperatorParser.php
+++ b/src/Request/FilterOperatorParser.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Freema\ReactAdminApiBundle\Request;
+
+/**
+ * Parse a react-admin filter key like `createdAt_gte` or `email_contains` into a
+ * (field, operator) tuple. Used by ListTrait::applyFilters to translate the
+ * incoming query string into Doctrine QueryBuilder predicates.
+ *
+ * Backward compatible: a bare key like `email` resolves to ('email', 'eq').
+ */
+final class FilterOperatorParser
+{
+    /**
+     * Operator suffixes ordered longest-first so the parser does not greedy-match
+     * a prefix that happens to spell a shorter operator (e.g. `_gte` before `_gt`,
+     * `_isNotNull` before `_isNull`).
+     *
+     * @var list<string>
+     */
+    public const OPERATORS = [
+        '_isNotNull',
+        '_startsWith',
+        '_endsWith',
+        '_contains',
+        '_between',
+        '_isNull',
+        '_nin',
+        '_neq',
+        '_gte',
+        '_lte',
+        '_in',
+        '_gt',
+        '_lt',
+    ];
+
+    /**
+     * @return array{0: string, 1: string} {field, operator without leading underscore}
+     */
+    public function parse(string $key): array
+    {
+        foreach (self::OPERATORS as $suffix) {
+            if (str_ends_with($key, $suffix) && strlen($key) > strlen($suffix)) {
+                return [substr($key, 0, -strlen($suffix)), substr($suffix, 1)];
+            }
+        }
+
+        return [$key, 'eq'];
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function supportedOperators(): array
+    {
+        $names = ['eq'];
+        foreach (self::OPERATORS as $op) {
+            $names[] = substr($op, 1);
+        }
+        sort($names);
+
+        return $names;
+    }
+}

--- a/src/SoftDeleteTrait.php
+++ b/src/SoftDeleteTrait.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Freema\ReactAdminApiBundle;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Freema\ReactAdminApiBundle\Interface\SoftDeletableEntityInterface;
+use Freema\ReactAdminApiBundle\Request\DeleteDataRequest;
+use Freema\ReactAdminApiBundle\Result\DeleteDataResult;
+
+/**
+ * Drop-in alternative to DeleteTrait that performs soft delete when the underlying
+ * entity implements SoftDeletableEntityInterface. Falls back to physical remove for
+ * everything else so existing repositories keep working when they mix entity kinds.
+ *
+ * Pair with `applySoftDeleteScope(QueryBuilder)` inside your list query (or rely on
+ * SoftDeleteListenerInterface if you wire it via Doctrine's filter API).
+ */
+trait SoftDeleteTrait
+{
+    public function delete(DeleteDataRequest $request): DeleteDataResult
+    {
+        if (!$this instanceof ServiceEntityRepository) {
+            throw new \LogicException(sprintf('Trait %s can be used only in a ServiceEntityRepository', self::class));
+        }
+
+        $entity = $this->find($request->getId());
+        if ($entity === null) {
+            return new DeleteDataResult($request->getId());
+        }
+
+        $em = $this->getEntityManager();
+        if ($entity instanceof SoftDeletableEntityInterface) {
+            if ($entity->getDeletedAt() === null) {
+                $entity->setDeletedAt(new \DateTimeImmutable());
+                $em->flush();
+            }
+        } else {
+            $em->remove($entity);
+            $em->flush();
+        }
+
+        return new DeleteDataResult($request->getId());
+    }
+
+    /**
+     * Apply a "WHERE deleted_at IS NULL" predicate when the entity is soft-deletable.
+     * Call this from your `list()` override before adding filters so soft-deleted rows
+     * never leak through. Skipped when `$includeDeleted` is true.
+     */
+    protected function applySoftDeleteScope(QueryBuilder $qb, string $alias = 'e', bool $includeDeleted = false): void
+    {
+        if ($includeDeleted) {
+            return;
+        }
+        $entityClass = $this->getClassName();
+        if (!is_subclass_of($entityClass, SoftDeletableEntityInterface::class)) {
+            return;
+        }
+        $qb->andWhere(sprintf('%s.deletedAt IS NULL', $alias));
+    }
+}

--- a/tests/Request/FilterOperatorParserTest.php
+++ b/tests/Request/FilterOperatorParserTest.php
@@ -16,7 +16,7 @@ final class FilterOperatorParserTest extends TestCase
         $this->parser = new FilterOperatorParser();
     }
 
-    public function testBareFieldDefaultsToEq(): void
+    public function test_bare_field_defaults_to_eq(): void
     {
         self::assertSame(['email', 'eq'], $this->parser->parse('email'));
     }
@@ -46,18 +46,18 @@ final class FilterOperatorParserTest extends TestCase
     /**
      * @dataProvider suffixCases
      */
-    public function testParsesKnownSuffixes(string $key, string $expectedField, string $expectedOp): void
+    public function test_parses_known_suffixes(string $key, string $expectedField, string $expectedOp): void
     {
         self::assertSame([$expectedField, $expectedOp], $this->parser->parse($key));
     }
 
-    public function testNeverLeavesEmptyFieldName(): void
+    public function test_never_leaves_empty_field_name(): void
     {
         // '_gte' alone is treated as a bare field (no real field name in front).
         self::assertSame(['_gte', 'eq'], $this->parser->parse('_gte'));
     }
 
-    public function testSupportedOperatorsAreUnique(): void
+    public function test_supported_operators_are_unique(): void
     {
         $ops = $this->parser->supportedOperators();
         self::assertSame($ops, array_values(array_unique($ops)));

--- a/tests/Request/FilterOperatorParserTest.php
+++ b/tests/Request/FilterOperatorParserTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Freema\ReactAdminApiBundle\Tests\Request;
+
+use Freema\ReactAdminApiBundle\Request\FilterOperatorParser;
+use PHPUnit\Framework\TestCase;
+
+final class FilterOperatorParserTest extends TestCase
+{
+    private FilterOperatorParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new FilterOperatorParser();
+    }
+
+    public function testBareFieldDefaultsToEq(): void
+    {
+        self::assertSame(['email', 'eq'], $this->parser->parse('email'));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function suffixCases(): array
+    {
+        return [
+            'gt' => ['age_gt', 'age', 'gt'],
+            'gte (prefers long match over gt)' => ['age_gte', 'age', 'gte'],
+            'lt' => ['age_lt', 'age', 'lt'],
+            'lte' => ['age_lte', 'age', 'lte'],
+            'neq' => ['status_neq', 'status', 'neq'],
+            'in' => ['id_in', 'id', 'in'],
+            'nin' => ['id_nin', 'id', 'nin'],
+            'between' => ['createdAt_between', 'createdAt', 'between'],
+            'isNull' => ['deletedAt_isNull', 'deletedAt', 'isNull'],
+            'isNotNull (prefers long match over isNull)' => ['deletedAt_isNotNull', 'deletedAt', 'isNotNull'],
+            'contains' => ['name_contains', 'name', 'contains'],
+            'startsWith' => ['slug_startsWith', 'slug', 'startsWith'],
+            'endsWith' => ['email_endsWith', 'email', 'endsWith'],
+        ];
+    }
+
+    /**
+     * @dataProvider suffixCases
+     */
+    public function testParsesKnownSuffixes(string $key, string $expectedField, string $expectedOp): void
+    {
+        self::assertSame([$expectedField, $expectedOp], $this->parser->parse($key));
+    }
+
+    public function testNeverLeavesEmptyFieldName(): void
+    {
+        // '_gte' alone is treated as a bare field (no real field name in front).
+        self::assertSame(['_gte', 'eq'], $this->parser->parse('_gte'));
+    }
+
+    public function testSupportedOperatorsAreUnique(): void
+    {
+        $ops = $this->parser->supportedOperators();
+        self::assertSame($ops, array_values(array_unique($ops)));
+        self::assertContains('eq', $ops);
+        self::assertContains('between', $ops);
+        self::assertContains('isNotNull', $ops);
+    }
+}


### PR DESCRIPTION
## Summary

Ships three opt-in primitives that previously required ad-hoc copy-pasting in every consumer:

1. **`FilterOperatorParser`** — translates RA filter keys (`createdAt_gte`, `id_in`, `email_contains`, `deletedAt_isNotNull`, …) into `(field, operator)` tuples your repository can switch over.
2. **`SoftDeletableEntityInterface` + `SoftDeleteTrait`** — drop-in soft-delete behaviour with `applySoftDeleteScope()` for list-side filtering and a transparent fallback to physical remove for mixed repositories.
3. **`subscribeResource(apiUrl, resource, onEvent, opts?)`** — tiny EventSource wrapper that pairs with any SSE source (Mercure topic, hand-rolled `StreamedResponse`, SaaS) and forwards JSON events to a callback.

## Why opt-in over auto-wired

The original ticket suggested wiring operator translation directly into `ListTrait` and shipping a default `/api/_stream/{resource}` controller. After looking at how consumers actually use the bundle, I deliberately kept the integration explicit:

- **Operator translation:** every project needs a whitelist of filterable fields (security), each repository has slightly different aliases / joins, and Doctrine parameter binding has quirks per operator. Hard-coding the translation would force every consumer onto a one-size-fits-all pattern. The doc page ships a recipe (~30 lines) that covers the 90 % case.
- **SSE transport:** dev environments want a `StreamedResponse` loop; production wants Mercure (or Pusher, or Centrifugo). Shipping a default ties the bundle to a transport that won't fit anyone perfectly.

## What's in

### PHP
- `src/Request/FilterOperatorParser` (+ supports introspection via `supportedOperators()`)
- `src/Interface/SoftDeletableEntityInterface`
- `src/SoftDeleteTrait` (delete + `applySoftDeleteScope`)
- `tests/Request/FilterOperatorParserTest` — full suffix matrix + tie-breakers

### TypeScript
- `assets/src/realtime/subscribeResource.ts`
- `assets/tests/subscribeResource.test.ts` — default URL, override, JSON dispatch, heartbeat tolerance

### Documentation
- `doc/filter-operators.md` — operator table, repository integration recipe, frontend usage, security notes
- `doc/soft-delete.md` — entity contract, repository wiring, `include_deleted` toggle, restore guidance
- `doc/realtime-sse.md` — event format, options, Mercure / StreamedResponse / polling integration patterns

## Test plan

- [ ] `vendor/bin/phpunit tests/Request/FilterOperatorParserTest.php`
- [ ] In a host project: extend a repository with the recipe from `doc/filter-operators.md`, hit `?filter={"createdAt_gte":"2026-01-01","id_in":[1,2,3]}` and confirm DQL ↔ SQL.
- [ ] `npm test` — `subscribeResource.test.ts` passes.
- [ ] Wire `SoftDeleteTrait` into a Notification repository; confirm `DELETE /api/notifications/1` returns 200 and the row stays in the table with `deletedAt` set; `GET /api/notifications` excludes it; `GET /api/notifications?filter={"include_deleted":1}` includes it.

## Backward compatibility

Purely additive. No existing behaviour changes — every primitive is opt-in.

## Follow-ups

- Reference `useNotificationsLive()` hook in `dev/admin-app` once the dev app gets the React 19 / RA 5.10 bump (T14 deferral).
- Bundled `react_admin_api.list.filterable_fields` config option to enforce whitelists declaratively (currently a recipe; could move into the trait).
